### PR TITLE
Add database_socket option to all modules. (#84)

### DIFF
--- a/changelogs/fragments/84-ovs-modules-database-socket.yaml
+++ b/changelogs/fragments/84-ovs-modules-database-socket.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+ - openvswitch modules got support for database socket parameter.

--- a/plugins/modules/openvswitch_db.py
+++ b/plugins/modules/openvswitch_db.py
@@ -61,6 +61,12 @@ options:
     description:
     - How long to wait for ovs-vswitchd to respond
     type: int
+  database_socket:
+    description:
+    - Path/ip to datbase socket to use
+    - Default path is used if not specified
+    - Path should start with 'unix:' prefix
+    type: str
 """
 
 EXAMPLES = """
@@ -95,6 +101,14 @@ EXAMPLES = """
     record: port0
     col: tag
     value: 10
+
+# Mark port with tag 10 for OVSDB with socket in /opt/second.sock
+- openvswitch.openvswitch.openvswitch_db:
+    table: Port
+    record: port0
+    col: tag
+    value: 10
+    database_socket: unix:/opt/second.sock
 """
 import re
 
@@ -217,6 +231,7 @@ def main():
         "key": {"required": False, "no_log": False},
         "value": {"type": "str"},
         "timeout": {"default": 5, "type": "int"},
+        "database_socket": {"default": None},
     }
 
     module = AnsibleModule(
@@ -227,6 +242,10 @@ def main():
 
     # We add ovs-vsctl to module_params to later build up templatized commands
     module.params["ovs-vsctl"] = module.get_bin_path("ovs-vsctl", True)
+    if module.params.get("database_socket"):
+        module.params["ovs-vsctl"] += " --db=" + module.params.get(
+            "database_socket"
+        )
 
     if module.params["state"] == "present" and not module.params["value"]:
         module.fail_json(

--- a/plugins/modules/openvswitch_port.py
+++ b/plugins/modules/openvswitch_port.py
@@ -56,6 +56,12 @@ options:
     - Set multiple properties on a port.
     type: list
     elements: str
+  database_socket:
+    description:
+    - Path/ip to datbase socket to use
+    - Default path is used if not specified
+    - Path should start with 'unix:' prefix
+    type: str
 """
 
 EXAMPLES = """
@@ -92,6 +98,15 @@ EXAMPLES = """
       attached-mac: 00:00:5E:00:53:23
       vm-id: '{{ inventory_hostname }}'
       iface-status: active
+
+# Plugs port veth0 into brdige br0 for database for OVSDB instance
+# with socket unix:/opt/second_ovsdb.sock
+- openvswitch.openvswitch.openvswitch_port:
+    bridge: br0
+    port: veth0
+    state: present
+    database_socket: unix:/opt/second_ovsdb.sock
+
 """
 
 from ansible.module_utils.basic import AnsibleModule
@@ -249,6 +264,7 @@ def main():
         "timeout": {"default": 5, "type": "int"},
         "external_ids": {"default": None, "type": "dict"},
         "tag": {"default": None},
+        "database_socket": {"default": None},
         "set": {"required": False, "type": "list", "elements": "str"},
     }
 
@@ -260,6 +276,10 @@ def main():
 
     # We add ovs-vsctl to module_params to later build up templatized commands
     module.params["ovs-vsctl"] = module.get_bin_path("ovs-vsctl", True)
+    if module.params.get("database_socket"):
+        module.params["ovs-vsctl"] += " --db=" + module.params.get(
+            "database_socket"
+        )
 
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)

--- a/tests/unit/modules/network/ovs/test_openvswitch_bond.py
+++ b/tests/unit/modules/network/ovs/test_openvswitch_bond.py
@@ -114,6 +114,24 @@ class TestOpenVSwitchBondModule(TestOpenVSwitchModule):
             test_name="test_openvswitch_bond_absent_removes_bond",
         )
 
+    def test_openvswitch_bond_database_socket(self):
+        set_module_args(
+            dict(
+                state="absent",
+                bridge="bond-br",
+                port="bond0",
+                database_socket="unix:/opt/second.sock",
+            )
+        )
+        commands = [
+            "/usr/bin/ovs-vsctl --db=unix:/opt/second.sock -t 5 del-port bond-br bond0"
+        ]
+        self.execute_module(
+            changed=True,
+            commands=commands,
+            test_name="test_openvswitch_bond_absent_removes_bond",
+        )
+
     def test_openvswitch_bond_present_idempotent(self):
         set_module_args(
             dict(

--- a/tests/unit/modules/network/ovs/test_openvswitch_bridge.py
+++ b/tests/unit/modules/network/ovs/test_openvswitch_bridge.py
@@ -212,6 +212,25 @@ class TestOpenVSwitchBridgeModule(TestOpenVSwitchModule):
             test_name="test_openvswitch_bridge_present_creates_fake_bridge",
         )
 
+    def test_openvswitch_bridge_uses_database_socket(self):
+        set_module_args(
+            dict(
+                state="present",
+                bridge="test-br2",
+                parent="test-br",
+                database_socket="unix:/opt/second.sock",
+                vlan=10,
+            )
+        )
+        commands = [
+            "/usr/bin/ovs-vsctl --db=unix:/opt/second.sock -t 5 add-br test-br2 test-br 10"
+        ]
+        self.execute_module(
+            changed=True,
+            commands=commands,
+            test_name="test_openvswitch_bridge_present_creates_fake_bridge",
+        )
+
     @pytest.mark.usefixtures("patched_openvswitch_bridge")
     def test_openvswitch_bridge_updates_vlan(self):
         set_module_args(

--- a/tests/unit/modules/network/ovs/test_openvswitch_db.py
+++ b/tests/unit/modules/network/ovs/test_openvswitch_db.py
@@ -237,6 +237,27 @@ class TestOpenVSwitchDBModule(TestOpenVSwitchModule):
             test_name="test_openvswitch_db_present_updates_key",
         )
 
+    def test_openvswitch_uses_database_socket(self):
+        set_module_args(
+            dict(
+                state="present",
+                table="Bridge",
+                record="test-br",
+                col="other_config",
+                key="disable-in-band",
+                database_socket="unix:/opt/second.sock",
+                value="false",
+            )
+        )
+        self.execute_module(
+            changed=True,
+            commands=[
+                "/usr/bin/ovs-vsctl --db=unix:/opt/second.sock -t 5 set Bridge test-br other_config"
+                ":disable-in-band=false"
+            ],
+            test_name="test_openvswitch_db_present_updates_key",
+        )
+
     def test_openvswitch_db_present_missing_key_on_map(self):
         set_module_args(
             dict(

--- a/tests/unit/modules/network/ovs/test_openvswitch_port.py
+++ b/tests/unit/modules/network/ovs/test_openvswitch_port.py
@@ -286,3 +286,24 @@ class TestOpenVSwitchPortModule(TestOpenVSwitchModule):
             commands=commands,
             test_name="test_openvswitch_port_present_runs_set_mode",
         )
+
+    def test_openvswitch_database_socket(self):
+        set_module_args(
+            dict(
+                state="present",
+                bridge="test-br",
+                port="eth2",
+                database_socket="unix:/opt/second.sock",
+                tag=10,
+                external_ids={"foo": "bar"},
+            )
+        )
+        commands = [
+            "/usr/bin/ovs-vsctl --db=unix:/opt/second.sock -t 5 add-port test-br eth2 tag=10",
+            "/usr/bin/ovs-vsctl --db=unix:/opt/second.sock -t 5 set port eth2 external_ids:foo=bar",
+        ]
+        self.execute_module(
+            changed=True,
+            commands=commands,
+            test_name="test_openvswitch_port_present_creates_port",
+        )


### PR DESCRIPTION
Add database_socket option to all modules.

SUMMARY
This should allow to use modules for unusual situations when
there are two or more independent OVS databases on the host.
It's implemented as passing --db={database_socket} to all OVS commands.
ISSUE TYPE

Feature Pull Request

COMPONENT NAME

openvswitch_port
openvswitch_db
openvswitch_bridge
openvswitch_bond

ADDITIONAL INFORMATION
I found that my code with multiple OVS bridges can't be configured by openvswitch modules and add database_socket option. It's supported by OVS itself, so it's a minor change.

Reviewed-by: Nilashish Chakraborty <nilashishchakraborty8@gmail.com>
Reviewed-by: None <None>